### PR TITLE
Add types to npm package

### DIFF
--- a/helpers.d.ts
+++ b/helpers.d.ts
@@ -1,0 +1,3 @@
+export declare function pattern(route?: string): boolean;
+export declare function parseQuery(str: string, params: any): {};
+export declare function stringifyQuery(obj: {}, params: any): string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,18 +1,6 @@
 interface SubmitEvent extends Event {
     submitter: HTMLElement;
 }
-export interface Prefs {
-    query: {
-        array: {
-            separator: string;
-            format: 'bracket' | 'separator';
-        };
-        nesting: number;
-        [key: string]: any;
-    };
-    sideEffect: boolean;
-}
-export declare const prefs: Prefs;
 export declare const path: {
     subscribe: (run: (value: any) => void, invalidate?: (value?: any) => void) => () => void;
     update: (reducer: any) => void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,33 @@
+interface SubmitEvent extends Event {
+    submitter: HTMLElement;
+}
+export interface Prefs {
+    query: {
+        array: {
+            separator: string;
+            format: 'bracket' | 'separator';
+        };
+        nesting: number;
+        [key: string]: any;
+    };
+    sideEffect: boolean;
+}
+export declare const prefs: Prefs;
+export declare const path: {
+    subscribe: (run: (value: any) => void, invalidate?: (value?: any) => void) => () => void;
+    update: (reducer: any) => void;
+    set: (value: any) => void;
+};
+export declare const query: {
+    subscribe: (run: (value: any) => void, invalidate?: (value?: any) => void) => () => void;
+    update: (reducer: any) => void;
+    set: (value: any) => void;
+};
+export declare const fragment: import("svelte/store").Writable<string>;
+export declare const state: import("svelte/store").Writable<{}>;
+export declare const url: import("svelte/store").Readable<string>;
+export declare function goto(url: string, data: {}): void;
+export declare function back(pathname?: string): void;
+export declare function click(e: MouseEvent): void;
+export declare function submit(e: SubmitEvent): void;
+export {};

--- a/index.js
+++ b/index.js
@@ -4,6 +4,9 @@
 	(global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.pathfinder = {}, global.svelte, global.store));
 }(this, (function (exports, svelte, store) { 'use strict';
 
+	const specialLinks = /((mailto:\w+)|(tel:\w+)).+/;
+	const hasLocation = typeof location !== 'undefined';
+	const hasProcess = typeof process !== 'undefined';
 	const hasHistory = typeof history !== 'undefined';
 	const hasWindow = typeof window !== 'undefined';
 	const subWindow = hasWindow && window !== window.parent;
@@ -203,8 +206,6 @@
 	    };
 	}
 
-	const specialLinks = /((mailto:\w+)|(tel:\w+)).+/;
-	const hasLocation = typeof location !== 'undefined', hasProcess = typeof process !== 'undefined';
 	const pathname = hasLocation ? location.pathname : '', search = hasLocation ? location.search : '', hash = hasLocation ? location.hash : '';
 	let popstate = false, len = 0;
 	const path = pathStore(pathname);

--- a/index.js
+++ b/index.js
@@ -167,31 +167,9 @@
 	    }).join('&');
 	}
 
-	const pathStore = createStore(path => {
-	    if (!(path instanceof String))
-	        path = new String(path);
-	    return Object.assign(path, { pattern });
-	});
-	const queryStore = createStore(query => {
-	    if (typeof query !== 'string')
-	        query = stringifyQuery(query, prefs.query);
-	    return Object.assign(new String(query), parseQuery(query, prefs.query));
-	});
-	function createStore(create) {
-	    return value => {
-	        const { subscribe, update, set } = store.writable(create(value));
-	        return {
-	            subscribe,
-	            update: reducer => update(value => create(reducer(value))),
-	            set: value => set(create(value))
-	        };
-	    };
-	}
-
-	const specialLinks = /((mailto:\w+)|(tel:\w+)).+/;
-	const hasWindow = typeof window !== 'undefined', hasHistory = typeof history !== 'undefined', hasLocation = typeof location !== 'undefined', hasProcess = typeof process !== 'undefined', subWindow = hasWindow && window !== window.parent, sideEffect = hasWindow && hasHistory && !subWindow;
+	const hasWindow = typeof window !== 'undefined', hasHistory = typeof history !== 'undefined', hasLocation = typeof location !== 'undefined', subWindow = hasWindow && window !== window.parent, sideEffect = hasWindow && hasHistory && !subWindow;
 	const pathname = hasLocation ? location.pathname : '', search = hasLocation ? location.search : '', hash = hasLocation ? location.hash : '';
-	let popstate = false, len = 0;
+	let popstate = false;
 	const prefs = {
 	    query: {
 	        array: {
@@ -228,7 +206,6 @@
 	        if (popstate)
 	            return popstate = false;
 	        history.pushState({}, null, $url);
-	        len++;
 	    });
 	    state.subscribe($state => {
 	        if (!prefs.sideEffect)
@@ -250,13 +227,97 @@
 	    fragment.set(hash);
 	    data && svelte.tick().then(() => state.set(data));
 	}
+
+	const pathStore = createStore(path => {
+	    if (!(path instanceof String))
+	        path = new String(path);
+	    return Object.assign(path, { pattern });
+	});
+	const queryStore = createStore(query => {
+	    if (typeof query !== 'string')
+	        query = stringifyQuery(query, prefs.query);
+	    return Object.assign(new String(query), parseQuery(query, prefs.query));
+	});
+	function createStore(create) {
+	    return value => {
+	        const { subscribe, update, set } = store.writable(create(value));
+	        return {
+	            subscribe,
+	            update: reducer => update(value => create(reducer(value))),
+	            set: value => set(create(value))
+	        };
+	    };
+	}
+
+	const specialLinks = /((mailto:\w+)|(tel:\w+)).+/;
+	const hasWindow$1 = typeof window !== 'undefined', hasHistory$1 = typeof history !== 'undefined', hasLocation$1 = typeof location !== 'undefined', hasProcess = typeof process !== 'undefined', subWindow$1 = hasWindow$1 && window !== window.parent, sideEffect$1 = hasWindow$1 && hasHistory$1 && !subWindow$1;
+	const pathname$1 = hasLocation$1 ? location.pathname : '', search$1 = hasLocation$1 ? location.search : '', hash$1 = hasLocation$1 ? location.hash : '';
+	let popstate$1 = false, len = 0;
+	const prefs$1 = {
+	    query: {
+	        array: {
+	            separator: ',',
+	            format: 'bracket'
+	        },
+	        nesting: 3
+	    },
+	    sideEffect: sideEffect$1
+	};
+	const path$1 = pathStore(pathname$1);
+	const query$1 = queryStore(search$1);
+	const fragment$1 = store.writable(hash$1, set => {
+	    const handler = () => set(location.hash);
+	    sideEffect$1 && prefs$1.sideEffect && window.addEventListener('hashchange', handler);
+	    return () => {
+	        sideEffect$1 && prefs$1.sideEffect && window.removeEventListener('hashchange', handler);
+	    };
+	});
+	const state$1 = store.writable({});
+	const url$1 = store.derived([path$1, query$1, fragment$1], ([$path, $query, $fragment], set) => {
+	    let skip = false;
+	    svelte.tick().then(() => {
+	        if (skip)
+	            return;
+	        set($path.toString() + $query.toString() + $fragment.toString());
+	    });
+	    return () => skip = true;
+	}, pathname$1 + search$1 + hash$1);
+	if (sideEffect$1) {
+	    url$1.subscribe($url => {
+	        if (!prefs$1.sideEffect)
+	            return;
+	        if (popstate$1)
+	            return popstate$1 = false;
+	        history.pushState({}, null, $url);
+	        len++;
+	    });
+	    state$1.subscribe($state => {
+	        if (!prefs$1.sideEffect)
+	            return;
+	        const url = location.pathname + location.search + location.hash;
+	        history.replaceState($state, null, url);
+	    });
+	    window.addEventListener('popstate', e => {
+	        if (!prefs$1.sideEffect)
+	            return;
+	        popstate$1 = true;
+	        goto$1(location.href, e.state);
+	    });
+	}
+	function goto$1(url = '', data) {
+	    const { pathname, search, hash } = new URL(url, 'file:');
+	    path$1.set(pathname);
+	    query$1.set(search);
+	    fragment$1.set(hash);
+	    data && svelte.tick().then(() => state$1.set(data));
+	}
 	function back(pathname = '/') {
-	    if (len > 0 && sideEffect && prefs.sideEffect) {
+	    if (len > 0 && sideEffect$1 && prefs$1.sideEffect) {
 	        history.back();
 	        len--;
 	    }
 	    else {
-	        svelte.tick().then(() => path.set(pathname));
+	        svelte.tick().then(() => path$1.set(pathname));
 	    }
 	}
 	function click(e) {
@@ -277,7 +338,7 @@
 	    if (!url || url.indexOf(location.origin) !== 0 || specialLinks.test(url))
 	        return;
 	    e.preventDefault();
-	    goto(url, Object.assign({}, a.dataset));
+	    goto$1(url, Object.assign({}, a.dataset));
 	}
 	function submit(e) {
 	    if (!e.target || e.defaultPrevented)
@@ -317,7 +378,7 @@
 	        url = url.replace(/^\/[a-zA-Z]:\//, '/');
 	    }
 	    e.preventDefault();
-	    goto(url, state);
+	    goto$1(url, state);
 	}
 	function isButton(el) {
 	    const tagName = el.tagName.toLocaleLowerCase(), type = el.type && el.type.toLocaleLowerCase();
@@ -327,14 +388,14 @@
 
 	exports.back = back;
 	exports.click = click;
-	exports.fragment = fragment;
-	exports.goto = goto;
-	exports.path = path;
-	exports.prefs = prefs;
-	exports.query = query;
-	exports.state = state;
+	exports.fragment = fragment$1;
+	exports.goto = goto$1;
+	exports.path = path$1;
+	exports.prefs = prefs$1;
+	exports.query = query$1;
+	exports.state = state$1;
 	exports.submit = submit;
-	exports.url = url;
+	exports.url = url$1;
 
 	Object.defineProperty(exports, '__esModule', { value: true });
 

--- a/index.mjs
+++ b/index.mjs
@@ -1,6 +1,9 @@
 import { tick } from 'svelte';
 import { writable, derived } from 'svelte/store';
 
+const specialLinks = /((mailto:\w+)|(tel:\w+)).+/;
+const hasLocation = typeof location !== 'undefined';
+const hasProcess = typeof process !== 'undefined';
 const hasHistory = typeof history !== 'undefined';
 const hasWindow = typeof window !== 'undefined';
 const subWindow = hasWindow && window !== window.parent;
@@ -200,8 +203,6 @@ function createStore(create) {
     };
 }
 
-const specialLinks = /((mailto:\w+)|(tel:\w+)).+/;
-const hasLocation = typeof location !== 'undefined', hasProcess = typeof process !== 'undefined';
 const pathname = hasLocation ? location.pathname : '', search = hasLocation ? location.search : '', hash = hasLocation ? location.hash : '';
 let popstate = false, len = 0;
 const path = pathStore(pathname);

--- a/index.mjs
+++ b/index.mjs
@@ -1,6 +1,21 @@
 import { tick } from 'svelte';
 import { writable, derived } from 'svelte/store';
 
+const hasHistory = typeof history !== 'undefined';
+const hasWindow = typeof window !== 'undefined';
+const subWindow = hasWindow && window !== window.parent;
+const sideEffect = hasWindow && hasHistory && !subWindow;
+const prefs = {
+    query: {
+        array: {
+            separator: ',',
+            format: 'bracket'
+        },
+        nesting: 3
+    },
+    sideEffect
+};
+
 function pattern(route = '') {
     const { pattern, keys } = parseParams(route);
     const pathname = this.toString(), matches = pattern.exec(pathname);
@@ -164,19 +179,31 @@ function stringifyObject(obj = {}, nesting = '') {
     }).join('&');
 }
 
-const hasWindow = typeof window !== 'undefined', hasHistory = typeof history !== 'undefined', hasLocation = typeof location !== 'undefined', subWindow = hasWindow && window !== window.parent, sideEffect = hasWindow && hasHistory && !subWindow;
+const pathStore = createStore(path => {
+    if (!(path instanceof String))
+        path = new String(path);
+    return Object.assign(path, { pattern });
+});
+const queryStore = createStore(query => {
+    if (typeof query !== 'string')
+        query = stringifyQuery(query, prefs.query);
+    return Object.assign(new String(query), parseQuery(query, prefs.query));
+});
+function createStore(create) {
+    return value => {
+        const { subscribe, update, set } = writable(create(value));
+        return {
+            subscribe,
+            update: reducer => update(value => create(reducer(value))),
+            set: value => set(create(value))
+        };
+    };
+}
+
+const specialLinks = /((mailto:\w+)|(tel:\w+)).+/;
+const hasLocation = typeof location !== 'undefined', hasProcess = typeof process !== 'undefined';
 const pathname = hasLocation ? location.pathname : '', search = hasLocation ? location.search : '', hash = hasLocation ? location.hash : '';
-let popstate = false;
-const prefs = {
-    query: {
-        array: {
-            separator: ',',
-            format: 'bracket'
-        },
-        nesting: 3
-    },
-    sideEffect
-};
+let popstate = false, len = 0;
 const path = pathStore(pathname);
 const query = queryStore(search);
 const fragment = writable(hash, set => {
@@ -203,6 +230,7 @@ if (sideEffect) {
         if (popstate)
             return popstate = false;
         history.pushState({}, null, $url);
+        len++;
     });
     state.subscribe($state => {
         if (!prefs.sideEffect)
@@ -224,97 +252,13 @@ function goto(url = '', data) {
     fragment.set(hash);
     data && tick().then(() => state.set(data));
 }
-
-const pathStore = createStore(path => {
-    if (!(path instanceof String))
-        path = new String(path);
-    return Object.assign(path, { pattern });
-});
-const queryStore = createStore(query => {
-    if (typeof query !== 'string')
-        query = stringifyQuery(query, prefs.query);
-    return Object.assign(new String(query), parseQuery(query, prefs.query));
-});
-function createStore(create) {
-    return value => {
-        const { subscribe, update, set } = writable(create(value));
-        return {
-            subscribe,
-            update: reducer => update(value => create(reducer(value))),
-            set: value => set(create(value))
-        };
-    };
-}
-
-const specialLinks = /((mailto:\w+)|(tel:\w+)).+/;
-const hasWindow$1 = typeof window !== 'undefined', hasHistory$1 = typeof history !== 'undefined', hasLocation$1 = typeof location !== 'undefined', hasProcess = typeof process !== 'undefined', subWindow$1 = hasWindow$1 && window !== window.parent, sideEffect$1 = hasWindow$1 && hasHistory$1 && !subWindow$1;
-const pathname$1 = hasLocation$1 ? location.pathname : '', search$1 = hasLocation$1 ? location.search : '', hash$1 = hasLocation$1 ? location.hash : '';
-let popstate$1 = false, len = 0;
-const prefs$1 = {
-    query: {
-        array: {
-            separator: ',',
-            format: 'bracket'
-        },
-        nesting: 3
-    },
-    sideEffect: sideEffect$1
-};
-const path$1 = pathStore(pathname$1);
-const query$1 = queryStore(search$1);
-const fragment$1 = writable(hash$1, set => {
-    const handler = () => set(location.hash);
-    sideEffect$1 && prefs$1.sideEffect && window.addEventListener('hashchange', handler);
-    return () => {
-        sideEffect$1 && prefs$1.sideEffect && window.removeEventListener('hashchange', handler);
-    };
-});
-const state$1 = writable({});
-const url$1 = derived([path$1, query$1, fragment$1], ([$path, $query, $fragment], set) => {
-    let skip = false;
-    tick().then(() => {
-        if (skip)
-            return;
-        set($path.toString() + $query.toString() + $fragment.toString());
-    });
-    return () => skip = true;
-}, pathname$1 + search$1 + hash$1);
-if (sideEffect$1) {
-    url$1.subscribe($url => {
-        if (!prefs$1.sideEffect)
-            return;
-        if (popstate$1)
-            return popstate$1 = false;
-        history.pushState({}, null, $url);
-        len++;
-    });
-    state$1.subscribe($state => {
-        if (!prefs$1.sideEffect)
-            return;
-        const url = location.pathname + location.search + location.hash;
-        history.replaceState($state, null, url);
-    });
-    window.addEventListener('popstate', e => {
-        if (!prefs$1.sideEffect)
-            return;
-        popstate$1 = true;
-        goto$1(location.href, e.state);
-    });
-}
-function goto$1(url = '', data) {
-    const { pathname, search, hash } = new URL(url, 'file:');
-    path$1.set(pathname);
-    query$1.set(search);
-    fragment$1.set(hash);
-    data && tick().then(() => state$1.set(data));
-}
 function back(pathname = '/') {
-    if (len > 0 && sideEffect$1 && prefs$1.sideEffect) {
+    if (len > 0 && sideEffect && prefs.sideEffect) {
         history.back();
         len--;
     }
     else {
-        tick().then(() => path$1.set(pathname));
+        tick().then(() => path.set(pathname));
     }
 }
 function click(e) {
@@ -335,7 +279,7 @@ function click(e) {
     if (!url || url.indexOf(location.origin) !== 0 || specialLinks.test(url))
         return;
     e.preventDefault();
-    goto$1(url, Object.assign({}, a.dataset));
+    goto(url, Object.assign({}, a.dataset));
 }
 function submit(e) {
     if (!e.target || e.defaultPrevented)
@@ -375,7 +319,7 @@ function submit(e) {
         url = url.replace(/^\/[a-zA-Z]:\//, '/');
     }
     e.preventDefault();
-    goto$1(url, state);
+    goto(url, state);
 }
 function isButton(el) {
     const tagName = el.tagName.toLocaleLowerCase(), type = el.type && el.type.toLocaleLowerCase();
@@ -383,4 +327,4 @@ function isButton(el) {
         ['button', 'submit', 'image'].includes(type)));
 }
 
-export { back, click, fragment$1 as fragment, goto$1 as goto, path$1 as path, prefs$1 as prefs, query$1 as query, state$1 as state, submit, url$1 as url };
+export { back, click, fragment, goto, path, query, state, submit, url };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "svelte-pathfinder",
-	"version": "2.0.0",
+	"version": "2.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
 	},
 	"files": [
 		"index.js",
+		"index.d.ts",
 		"index.mjs"
 	],
+	"types": "index.d.ts",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/PaulMaly/svelte-pathfinder.git"

--- a/shared.d.ts
+++ b/shared.d.ts
@@ -1,3 +1,6 @@
+export declare const specialLinks: RegExp;
+export declare const hasLocation: boolean;
+export declare const hasProcess: boolean;
 export declare const sideEffect: boolean;
 export interface Prefs {
     query: {

--- a/shared.d.ts
+++ b/shared.d.ts
@@ -1,0 +1,13 @@
+export declare const sideEffect: boolean;
+export interface Prefs {
+    query: {
+        array: {
+            separator: string;
+            format: 'bracket' | 'separator';
+        };
+        nesting: number;
+        [key: string]: any;
+    };
+    sideEffect: boolean;
+}
+export declare const prefs: Prefs;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { tick } from 'svelte';
 import { derived, writable } from 'svelte/store';
+import { prefs, sideEffect } from './shared';
 
 import { pathStore, queryStore } from './stores';
 
@@ -7,28 +8,12 @@ interface SubmitEvent extends Event {
 	submitter: HTMLElement;
 }
 
-export interface Prefs {
-	query: {
-		array: {
-			separator: string
-			format: 'bracket' | 'separator'
-		}
-		nesting: number;
-		[key: string]: any;
-	};
-	sideEffect: boolean;
-}
-
 type HTMLFormControl = HTMLButtonElement & HTMLSelectElement & HTMLDataListElement & HTMLTextAreaElement & HTMLInputElement;
 
 const specialLinks = /((mailto:\w+)|(tel:\w+)).+/;
 
-const hasWindow = typeof window !== 'undefined',
-	hasHistory = typeof history !== 'undefined',
-	hasLocation = typeof location !== 'undefined',
-	hasProcess = typeof process !== 'undefined',
-	subWindow = hasWindow && window !== window.parent,
-	sideEffect = hasWindow && hasHistory && !subWindow;
+const hasLocation = typeof location !== 'undefined',
+	hasProcess = typeof process !== 'undefined';
 
 const pathname = hasLocation ? location.pathname : '',
 	search = hasLocation ? location.search : '',
@@ -36,17 +21,6 @@ const pathname = hasLocation ? location.pathname : '',
 
 let popstate = false,
 	len = 0;
-
-export const prefs: Prefs = {
-	query: {
-		array: {
-			separator: ',',
-			format: 'bracket'
-		},
-		nesting: 3
-	},
-	sideEffect
-};
 
 export const path = pathStore(pathname);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,12 @@
 import { tick } from 'svelte';
 import { derived, writable } from 'svelte/store';
-import { prefs, sideEffect } from './shared';
+import {
+	hasLocation,
+	hasProcess,
+	prefs,
+	sideEffect,
+	specialLinks,
+} from './shared';
 
 import { pathStore, queryStore } from './stores';
 
@@ -9,11 +15,6 @@ interface SubmitEvent extends Event {
 }
 
 type HTMLFormControl = HTMLButtonElement & HTMLSelectElement & HTMLDataListElement & HTMLTextAreaElement & HTMLInputElement;
-
-const specialLinks = /((mailto:\w+)|(tel:\w+)).+/;
-
-const hasLocation = typeof location !== 'undefined',
-	hasProcess = typeof process !== 'undefined';
 
 const pathname = hasLocation ? location.pathname : '',
 	search = hasLocation ? location.search : '',

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,3 +1,7 @@
+export const specialLinks = /((mailto:\w+)|(tel:\w+)).+/;
+
+export const hasLocation = typeof location !== 'undefined';
+export const hasProcess = typeof process !== 'undefined';
 const hasHistory = typeof history !== 'undefined';
 const hasWindow = typeof window !== 'undefined';
 const subWindow = hasWindow && window !== window.parent;

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,0 +1,29 @@
+const hasHistory = typeof history !== 'undefined';
+const hasWindow = typeof window !== 'undefined';
+const subWindow = hasWindow && window !== window.parent;
+
+export const sideEffect = hasWindow && hasHistory && !subWindow;
+
+export interface Prefs {
+	query: {
+		array: {
+			separator: string
+			format: 'bracket' | 'separator'
+		}
+		nesting: number;
+		[key: string]: any;
+	};
+	sideEffect: boolean;
+}
+
+
+export const prefs: Prefs = {
+	query: {
+		array: {
+			separator: ',',
+			format: 'bracket'
+		},
+		nesting: 3
+	},
+	sideEffect
+};

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -1,7 +1,7 @@
 import { writable } from 'svelte/store';
 
 import { pattern, stringifyQuery, parseQuery } from './helpers';
-import { prefs } from './index';
+import { prefs } from './shared';
 
 export const pathStore = createStore(path => {
 	if (!(path instanceof String)) path = new String(path);

--- a/stores.d.ts
+++ b/stores.d.ts
@@ -1,0 +1,10 @@
+export declare const pathStore: (value: any) => {
+    subscribe: (run: (value: any) => void, invalidate?: (value?: any) => void) => () => void;
+    update: (reducer: any) => void;
+    set: (value: any) => void;
+};
+export declare const queryStore: (value: any) => {
+    subscribe: (run: (value: any) => void, invalidate?: (value?: any) => void) => () => void;
+    update: (reducer: any) => void;
+    set: (value: any) => void;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
             "jest"
         ],
         "allowSyntheticDefaultImports": true,
-        "declaration": false,
+        "declaration": true,
         "diagnostics": true,
         "target": "es2017",
         "module": "esnext",


### PR DESCRIPTION
My VS Code is complaining that types are not available:
```
Could not find a declaration file for module 'svelte-pathfinder'. '.../node_modules/.pnpm/svelte-pathfinder@2.1.2_svelte@3.31.0/node_modules/svelte-pathfinder/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/svelte-pathfinder` if it exists or add a new declaration (.d.ts) file containing `declare module 'svelte-pathfinder';`ts(7016)
```

`@types/svelte-pathfinder` doesn't exist, but  yet the svelte-pathfinder source code is actually in Typescript, so I went ahead and enabled declarations in `tsconfig.json`, so that types are emitted and can be included in the npm package directly.

The build output changed quite a bit for some reason. All my actual changes are in `package.json` and `tsconfig.json`. The rest is just changes caused by running `npm run build`.